### PR TITLE
将游戏作为网页应用解决无法在iOS设备上全屏显示的问题

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
         <title>合成大西瓜 - 冬日树ver</title>
         
         <!-- iOS主屏幕书签 -->
-        <meta name="apple-mobile-web-app-title" content="合成大西瓜"><!-- 名称 -->
+        <meta name="apple-mobile-web-app-title" content="合成大西瓜 - 冬日树ver"><!-- 名称 -->
         <meta name="apple-mobile-web-app-capable" content="yes"><!-- 全屏 -->
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent"><!-- 状态栏样式 -->
         <link rel="apple-touch-icon" sizes="180x180" href="./favicon.ico"><!-- 图标 -->

--- a/index.html
+++ b/index.html
@@ -6,6 +6,14 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
         <link rel="stylesheet" href="/style.css?v=1.1" />
         <title>合成大西瓜 - 冬日树ver</title>
+        
+        <!-- iOS主屏幕书签 -->
+        <meta name="apple-mobile-web-app-title" content="合成大西瓜"><!-- 名称 -->
+        <meta name="apple-mobile-web-app-capable" content="yes"><!-- 全屏 -->
+        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent"><!-- 状态栏样式 -->
+        <link rel="apple-touch-icon" sizes="180x180" href="./favicon.ico"><!-- 图标 -->
+        <link rel="apple-touch-startup-image" href="./startup.png"><!-- 启动屏幕 -->
+        
     </head>
     <body>
         <div id="root"></div>

--- a/public/style.css
+++ b/public/style.css
@@ -15,6 +15,10 @@ body {
     align-items: center;
 }
 
+ul {
+    padding-inline-start: 1em;
+}
+
 .btn {
     padding: 10px;
     background-color: #000000;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ function App() {
         }
         try {
             const obj = JSON.parse(data);
-            return obj.lastTime >= 1735622147612; // 需要更新的时候修改这个时间戳
+            return obj.lastTime >= 1736353581226; // 需要更新的时候修改这个时间戳
         } catch (e) {
             console.error(e);
             return false;
@@ -87,9 +87,17 @@ function App() {
                 visible={msgModalVisible}
                 title="提示"
                 content={
-                    <p>
-                        手机端浏览器如果出现画面显示不全，请尝试点击右上角“更多”按钮，进入全屏模式，或许可以解决问题。
-                    </p>
+                    <>
+                        <p>
+                            手机端浏览器若出现画面显示不全，可尝试以下方式解决：
+                        </p>
+                        <ul style={{ fontSize: "0.95em" }}>
+                            <li>点击右上角“更多”进入全屏模式</li>
+                            <li>
+                                iOS设备：点击浏览器底部分享按钮，选择“添加到主屏幕”后，以全屏打开
+                            </li>
+                        </ul>
+                    </>
                 }
                 footer={
                     <button


### PR DESCRIPTION
修改了index.html文件，添加了有关网页应用的元标签，使游戏可在ios上通过浏览器添加至主屏幕以网页应用的形式独立全屏显示，改善游玩体验

如何将网页添加到主屏幕：

- iOS设备：点击浏览器底部的分享按钮，然后选择“添加到主屏幕”。

- Android设备：在浏览器菜单中找到“添加到主屏幕”的选项。

建议可以添加适当的引导
![游戏](https://github.com/user-attachments/assets/e0ec1790-2ea1-4a67-8ec3-1e5cddcc2ac3)
![主屏幕](https://github.com/user-attachments/assets/e599d25e-8fa6-4705-b96a-761fce96bcf0)